### PR TITLE
Sleep between destroying machine and volume

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -151,10 +151,11 @@ function cleanupStep(
   volumes: string[]
 ) {
   const volumeDeletes = volumes.map((v) => `fly volumes delete ${v} -y`);
+  const wait10Seconds = `sleep 10`;
   const machineDeletes = machines.map(
     (id) => `fly machine remove -a ${applicationName} ${id} --force`
   );
-  const commands = machineDeletes.concat(volumeDeletes);
+  const commands = machineDeletes.concat(wait10Seconds).concat(volumeDeletes);
   return {
     label: ":broom: Clean up fly resources",
     commands,


### PR DESCRIPTION
Temp workaround to get around failing fly cleanup:
https://community.fly.io/t/volume-attached-to-destroyed-machine/10445/16

Original error:
```
Error failed deleting volume: This volume is attached to a machine(32874d09f64e85) and cannot be deleted
```
even though we already deleted `machine(32874d09f64e85)` in step before running this.
