### PR TITLE
Fix fly's machine api proxy command

### DIFF
--- a/fly/proxy.ts
+++ b/fly/proxy.ts
@@ -55,13 +55,12 @@ export class FlyProxy {
     const flyProxy = Deno.run({
       cmd: [
         "fly",
-        "--json",
+        "machine",
+        "api-proxy",
         "--access-token",
         this.apiToken,
         "--org",
         this.organization,
-        "machine",
-        "api-proxy",
       ],
       stdout: "piped",
       stderr: "piped",


### PR DESCRIPTION
I tried running locally and`fly machine api-proxy` does not support `--json` at all. Not sure if we did earlier but we don't seem to be using output from it.

Need to do a release again, unfortunately.