### PR TITLE
Allow secrets to be specified as a map

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -3,7 +3,7 @@ VERSION 0.6
 FROM denoland/deno:alpine-1.23.1
 
 compile:
-  COPY index.ts config.ts .
+  COPY index.ts config.ts createSecrets.ts .
   COPY fly fly
   ARG TARGET_PLATFORM=x86_64-unknown-linux-gnu
   RUN deno compile --target ${TARGET_PLATFORM} -o fly-buildkite-plugin-${TARGET_PLATFORM}  --allow-env --allow-run --allow-net index.ts
@@ -15,7 +15,7 @@ compile-all:
   BUILD --build-arg TARGET_PLATFORM=aarch64-apple-darwin +compile
 
 test:
-  COPY index.ts config.ts .
+  COPY index.ts config.ts createSecrets.ts createSecrets.test.ts .
   COPY fly fly
   RUN deno test
 

--- a/config.ts
+++ b/config.ts
@@ -3,7 +3,7 @@ export type Config = {
   organization: string;
   image: string;
   command: string;
-  secrets: Array<string>;
+  secrets: Array<string> | Record<string, string>;
   environment: Record<string, string>;
   cpus: number;
   memory: number;

--- a/createSecrets.test.ts
+++ b/createSecrets.test.ts
@@ -1,0 +1,63 @@
+import { assertRejects } from "https://deno.land/std@0.145.0/testing/asserts.ts";
+import * as mf from "https://deno.land/x/mock_fetch@0.3.0/mod.ts";
+import { createSecrets } from "./createSecrets.ts";
+
+Deno.test("createSecrets", () => {
+  mf.install();
+
+  Deno.test(
+    "createSecrets should throw an error if a secret is not set in environment",
+    async () => {
+      const originalEnvGet = Deno.env.get;
+      Deno.env.get = () => undefined;
+
+      await assertRejects(
+        () => createSecrets("testApp", "testToken", ["SECRET_KEY"]),
+        Error,
+        "Secret SECRET_KEY is not set in environment"
+      );
+
+      Deno.env.get = originalEnvGet; // Restore original function
+    }
+  );
+
+  Deno.test(
+    "createSecrets should throw an error if the fetch request fails",
+    async () => {
+      Deno.env.set("SECRET_KEY", "SECRET_VALUE");
+      mf.mock("POST@/graphql", () => {
+        return new Response("Error", {
+          status: 500,
+        });
+      });
+
+      await assertRejects(
+        () => createSecrets("testApp", "testToken", ["SECRET_KEY"]),
+        Error,
+        "Failed to create secrets: Fetch error"
+      );
+
+      Deno.env.delete("SECRET_KEY");
+      mf.reset();
+    }
+  );
+
+  Deno.test(
+    "createSecrets should not throw an error if the fetch request succeeds",
+    async () => {
+      Deno.env.set("SECRET_KEY", "SECRET_VALUE");
+      mf.mock("POST@/graphql", () => {
+        return new Response("OK", {
+          status: 200,
+        });
+      });
+
+      await createSecrets("testApp", "testToken", ["SECRET_KEY"]);
+
+      Deno.env.delete("SECRET_KEY");
+      mf.reset();
+    }
+  );
+
+  mf.uninstall();
+});

--- a/createSecrets.test.ts
+++ b/createSecrets.test.ts
@@ -59,5 +59,24 @@ Deno.test("createSecrets", () => {
     }
   );
 
+  Deno.test(
+    "createSecrets should secrets represented as a Record",
+    async () => {
+      Deno.env.set("SECRET_KEY_ON_BOX", "SECRET_VALUE");
+      mf.mock("POST@/graphql", () => {
+        return new Response("OK", {
+          status: 200,
+        });
+      });
+
+      await createSecrets("testApp", "testToken", {
+        SECRET_KEY_IN_FLY: "SECRET_KEY_ON_BOX",
+      });
+
+      Deno.env.delete("SECRET_KEY");
+      mf.reset();
+    }
+  );
+
   mf.uninstall();
 });

--- a/createSecrets.ts
+++ b/createSecrets.ts
@@ -1,0 +1,51 @@
+export async function createSecrets(
+  appName: string,
+  accessToken: string,
+  secrets: Array<string>
+) {
+  const query = `mutation MyMutation($appId: ID!, $secrets: [SecretInput!]!) {
+  setSecrets(
+    input: {
+      appId: $appId
+      secrets: $secrets
+      replaceAll: false
+    }
+  ) {
+    app {
+      name
+      secrets {
+        name,
+        createdAt
+      }
+    }
+  }
+}`;
+
+  const variables = {
+    appId: appName,
+    secrets: secrets.map((key) => {
+      const value = Deno.env.get(key);
+      if (!value) {
+        throw new Error(`Secret ${key} is not set in environment`);
+      }
+
+      return {
+        key,
+        value,
+      };
+    }),
+  };
+
+  const result = await fetch("https://api.fly.io/graphql", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  if (!result.ok) {
+    throw new Error(`Failed to create secrets: ${await result.text()}`);
+  }
+}

--- a/index.ts
+++ b/index.ts
@@ -3,60 +3,10 @@ import { writeAll } from "https://deno.land/std@0.145.0/streams/conversion.ts";
 
 import { applicationNameFromPipelineName } from "./fly/app.ts";
 import { Config, configFromEnv } from "./config.ts";
+
 import { FlyProxy } from "./fly/proxy.ts";
 import { assert } from "https://deno.land/std@0.145.0/_util/assert.ts";
-
-async function createSecrets(
-  appName: string,
-  accessToken: string,
-  secrets: Array<string>
-) {
-  const query = `mutation MyMutation($appId: ID!, $secrets: [SecretInput!]!) {
-  setSecrets(
-    input: {
-      appId: $appId
-      secrets: $secrets
-      replaceAll: false
-    }
-  ) {
-    app {
-      name
-      secrets {
-        name,
-        createdAt
-      }
-    }
-  }
-}`;
-
-  const variables = {
-    appId: appName,
-    secrets: secrets.map((key) => {
-      const value = Deno.env.get(key);
-      if (!value) {
-        throw new Error(`Secret ${key} is not set in environment`);
-      }
-
-      return {
-        key,
-        value,
-      };
-    }),
-  };
-
-  const result = await fetch("https://api.fly.io/graphql", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ query, variables }),
-  });
-
-  if (!result.ok) {
-    throw new Error(`Failed to create secrets: ${await result.text()}`);
-  }
-}
+import { createSecrets } from "./createSecrets.ts";
 
 type AppList = Array<{
   Name: string;

--- a/plugin.yml
+++ b/plugin.yml
@@ -11,7 +11,7 @@ configuration:
     organization:
       type: string
     secrets:
-      type: array
+      type: [array, object]
     env:
       type: object
     cpus:


### PR DESCRIPTION
This allows secrets to be specified as a map in addition to an array.

If secrets are specified as a map, then the key is the name of the
secret in Fly.io and the value is the environment variable that contains
the value of that secret on the host running the plugin. For example:

```yaml
secrets:
  SECRET_KEY_IN_FLY: SECRET_KEY_ON_BOX
```

Gets converted to:

```javascript
{
  secrets: {
    SECRET_KEY_IN_FLY: Deno.env.get("SECRET_KEY_ON_BOX")
  }
}
```

Related to RUN-2813