### PR TITLE
Fix create secret mutation format

### DIFF
--- a/createSecrets.test.ts
+++ b/createSecrets.test.ts
@@ -72,9 +72,12 @@ Deno.test("createSecrets", async (t) => {
         const text = await req.text();
         const body = JSON.parse(text);
         assertEquals(body.variables.appId, "testApp");
-        assertEquals(body.variables.secrets, {
-          SECRET_KEY_IN_FLY: "SECRET_VALUE",
-        });
+        assertEquals(body.variables.secrets, [
+          {
+            key: "SECRET_KEY_IN_FLY",
+            value: "SECRET_VALUE",
+          },
+        ]);
 
         return new Response("OK", {
           status: 200,

--- a/createSecrets.ts
+++ b/createSecrets.ts
@@ -52,9 +52,14 @@ export async function createSecrets(
     );
   }
 
+  const secretsArray = Object.entries(secretsMap).map(([key, value]) => ({
+    key,
+    value,
+  }));
+
   const variables = {
     appId: appName,
-    secrets: secretsMap,
+    secrets: secretsArray,
   };
 
   const result = await fetch("https://api.fly.io/graphql", {


### PR DESCRIPTION
Fly expects secrets to be an array instead of an object.