### PR TITLE
[BAC-4496] add fly api token to cleanup step

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -17,7 +17,7 @@ compile-all:
 test:
   COPY index.ts config.ts createSecrets.ts createSecrets.test.ts .
   COPY fly fly
-  RUN deno test
+  RUN deno test --allow-env
 
 # TODO(dmiller): try to imitate https://github.com/earthly/earthly/blob/main/release/Earthfile#L66 to release on GitHub
 # for now let's just do it by hand


### PR DESCRIPTION
Also did a little type futzing here to make `cleanupStep` return a `CommandStep` (and also to signal that `createMachine` might take a `CommandStep` lacking a `key` as an argument, what it returns always has one.)