### PR TITLE
remove the cleanup step key

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -130,7 +130,6 @@ async function createMachine(
 }
 
 function cleanupStep(
-  stepSuffix: string,
   applicationName: string,
   machines: string[],
   dependencies: string[],
@@ -144,7 +143,6 @@ function cleanupStep(
   const commands = machineDeletes.concat(wait2Mins).concat(volumeDeletes);
   return {
     label: ":broom: Clean up fly resources",
-    key: `cleanup-step-${stepSuffix}`,
     command: commands,
     // TODO(dmiller): instead of hardcoding this, maybe grab the buildkite agent tags from
     // [BUILDKITE_AGENT_META_DATA_*](https://buildkite.com/docs/pipelines/environment-variables#BUILDKITE_AGENT_META_DATA_)
@@ -173,11 +171,6 @@ async function main() {
     throw new Error("BUILDKITE_PIPELINE_SLUG is not set");
   }
   const applicationName = applicationNameFromPipelineName(pipelineName);
-
-  const stepID = Deno.env.get("BUILDKITE_STEP_ID");
-  if (!stepID) {
-    throw new Error("BUILDKITE_STEP_ID is not set");
-  }
 
   // create application if it doesn't exist
   console.error("Checking if application exists");
@@ -219,7 +212,7 @@ async function main() {
       const commandSteps = await Promise.all(commandPromises);
       const steps = [
         ...commandSteps,
-        cleanupStep(stepID, applicationName, machines, stepKeys, volumes),
+        cleanupStep(applicationName, machines, stepKeys, volumes),
       ];
       pipeline = { steps };
     } else {
@@ -240,13 +233,7 @@ async function main() {
       volumes.push(...volumesCreated);
       const steps = [
         step,
-        cleanupStep(
-          stepID,
-          applicationName,
-          machines,
-          stepKeys,
-          volumesCreated
-        ),
+        cleanupStep(applicationName, machines, stepKeys, volumesCreated),
       ];
       pipeline = { steps };
     }


### PR DESCRIPTION
If we have more than one plugin use in a given build pipeline, the keys will conflict and the pipeline upload will fail.  Given that we don't need to refer to the cleanup step for anything (like dependencies), just drop it.