### PR TITLE
fix the buildevents plugin syntax

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -94,7 +94,7 @@ async function createApplicationIfNotExists(
 // with a single key, with a value also an object of any number of k/v.  I have no idea how
 // to express that in typescript.
 // deno-lint-ignore no-explicit-any
-type Plugin = string | Record<string, any>;
+type Plugin = string | Record<string, Record<string, any>>;
 
 export type CommandStep = {
   label?: string;

--- a/index.ts
+++ b/index.ts
@@ -136,9 +136,7 @@ async function createMachine(
             },
           },
         },
-        {
-          "replayio/buildevents#adb8a05": "~",
-        },
+        "replayio/buildevents#adb8a05",
       ],
     },
     machineID,
@@ -177,9 +175,7 @@ function cleanupStep(
           },
         },
       },
-      {
-        "replayio/buildevents#adb8a05": "~",
-      },
+      "replayio/buildevents#adb8a05",
     ],
   };
 }


### PR DESCRIPTION
Carrying over the yaml syntax directly doesn't work.  This is something the typescript type would have caught if I knew how to write it:

```
// The Record<string,any> form here isn't as strict as I'd like - it should be an object
// with a single key, with a value also an object of any number of k/v.  I have no idea how
// to express that in typescript.
// deno-lint-ignore no-explicit-any
type Plugin = string | Record<string, any>;
```

I changed it to:

```
type Plugin = string | Record<string, Record<string,any>>;
```

The `string` in the outer `Record<>` is the one that should in fact only be a single key, not any number of them.  Still, the updated version gets us a little closer.  It does in fact catch the error from #17.
