### PR TITLE
bump the buildevents plugin to support steps without a `key:`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -136,7 +136,7 @@ async function createMachine(
             },
           },
         },
-        "replayio/buildevents#adb8a05",
+        "replayio/buildevents#2810143",
       ],
     },
     machineID,
@@ -175,7 +175,7 @@ function cleanupStep(
           },
         },
       },
-      "replayio/buildevents#adb8a05",
+      "replayio/buildevents#2810143",
     ],
   };
 }


### PR DESCRIPTION
The cleanup step doesn't have a key.  Let's not break that step's execution (and turn the build red).