### PR TITLE
mark the cleanup step as `soft_fail: true`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -104,6 +104,7 @@ export type CommandStep = {
   plugins?: Plugin[];
   agents?: string[];
   key?: string;
+  soft_fail?: boolean;
 };
 
 async function createMachine(
@@ -164,6 +165,7 @@ function cleanupStep(
     agents: ["deploy=true"],
     depends_on: dependencies,
     allow_dependency_failure: true,
+    soft_fail: true,
     plugins: [
       "thedyrt/skip-checkout#v0.1.1",
       {


### PR DESCRIPTION
Addresses RUN-3205

Unclear why the cleanup step in that issue failed the way it did.  The machine clearly existed and shouldn't have been destroyed elsewhere.